### PR TITLE
Create a github main page, & ability to view a list of orgs

### DIFF
--- a/app/assets/javascripts/organizations.coffee
+++ b/app/assets/javascripts/organizations.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -16,6 +16,10 @@ body {
   padding-top: 60px;
 }
 
+.main {
+  margin-top: 60px;
+}
+
 section {
   overflow: auto;
 }

--- a/app/assets/stylesheets/organizations.scss
+++ b/app/assets/stylesheets/organizations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Organizations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,0 +1,7 @@
+class OrganizationsController < ApplicationController
+
+  def index
+
+    @organizations = current_user.organizations
+  end
+end

--- a/app/helpers/organizations_helper.rb
+++ b/app/helpers/organizations_helper.rb
@@ -1,0 +1,2 @@
+module OrganizationsHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ActiveRecord::Base
   validates :password, presence: true, length: { minimum: 6 }, allow_nil: true
 
   def organizations
-    service.organizations
+    service.organizations(self)
   end
 
   def service

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -5,11 +5,11 @@ class GithubService
   end
 
   def organizations(current_user)
-    organizations = @_connection.get("/orgs") do |req|
+    response = @_connection.get do |req|
+      req.url 'orgs'
       req.headers[:Authorization] = "token #{current_user.github_access_token}"
     end
-    byebug
-    parsed_orgs = JSON.parse(organizations)
+    JSON.parse(response.body)
   end
 
 end

--- a/app/views/git_pages/show.html.erb
+++ b/app/views/git_pages/show.html.erb
@@ -9,6 +9,8 @@
   </aside>
   <div class="col-md-8">
     <h3>Github</h3>
-    <%= link_to "Organizations", organizations_url %>
+    <section class="main">
+      <h6><%= link_to "Organizations", organizations_url %></h6>
+    </section>
   </div>
 </div>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -1,0 +1,18 @@
+<div class="row">
+<aside class="col-md-4">
+  <section class="user_info">
+    <%= render '/shared/user_info' %>
+  </section>
+  <section class="stats">
+    <%= render 'shared/stats' %>
+  </section>
+</aside>
+<div class="col-md-8">
+  <h3>Github Organizations</h3>
+  <section class="main">
+    <% @organizations.each do |org| %>
+      <p><%= org['login'] %></p>
+    <% end %>
+  </section>
+</div>
+</div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,5 +1,5 @@
 <% if logged_in? %>
-  < div class="row">
+  <div class="row">
     <aside class="col-md-4">
       <section class="user_info">
         <%= render '/shared/user_info' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   get "/auth/github/callback", to: 'sessions#exchange_token'
 
   get "git_main", to: 'git_pages#show'
+  get "organizations", to: 'organizations#index'
 
   resources :users do
     member do

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class OrganizationsControllerTest < ActionController::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Create a github pages controller, and a git 'main' page to access github data. Create an Organizations controller. Create a link on the git main page that links to a list of the user's authorized organizations. 
