### PR TITLE
User sees the dm link correctly

### DIFF
--- a/app/models/directmessage.rb
+++ b/app/models/directmessage.rb
@@ -1,2 +1,6 @@
 class Directmessage < ActiveRecord::Base
+  has_one :sender, class_name: "User",
+                   foreign_key: "id"
+  has_one :receiver, class_name: "User",
+                     foreign_key: "id"
 end

--- a/db/migrate/20160614231005_create_directmessages.rb
+++ b/db/migrate/20160614231005_create_directmessages.rb
@@ -6,5 +6,7 @@ class CreateDirectmessages < ActiveRecord::Migration
 
       t.timestamps null: false
     end
+    add_index :directmessages, :sender_id
+    add_index :directmessages, :receiver_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,6 +23,9 @@ ActiveRecord::Schema.define(version: 20160614231005) do
     t.datetime "updated_at",  null: false
   end
 
+  add_index "directmessages", ["receiver_id"], name: "index_directmessages_on_receiver_id", using: :btree
+  add_index "directmessages", ["sender_id"], name: "index_directmessages_on_sender_id", using: :btree
+
   create_table "lists", force: :cascade do |t|
     t.string  "name"
     t.integer "owner_id"

--- a/test/integration/direct_messages_test.rb
+++ b/test/integration/direct_messages_test.rb
@@ -12,20 +12,17 @@ class DirectmessagesTest < ActionDispatch::IntegrationTest
     log_in_as(@michael)
   end
 
-  # test "a user sees the DM link on another user's show page" do
-  #   skip
-  #   get user_path(@archer)
-  #   assert_select 'a', {count: 1, text: "DM Me!"}
-  # end
-  #
-  # test "a user does not see the DM link on their own page" do
-  #   skip
-  #   get user_path(@michael)
-  #   assert_select 'a', {count: 0, text: "DM Me!"}
-  # end
+  test "a user sees the DM link on another user's show page" do
+    get user_path(@archer)
+    assert_select 'a', {count: 1, text: "DM Me!"}
+  end
+
+  test "a user does not see the DM link on their own page" do
+    get user_path(@michael)
+    assert_select 'a', {count: 0, text: "DM Me!"}
+  end
   #
   # test "following the DM route opens the DM creation form" do
-  #   skip
   #   get message_new_path(sender_id: @michael_id, receiver_id: @archer_id)
   #   assert_select 'form input' do
   #     assert_select "[name=?]", "message[content]"
@@ -33,7 +30,6 @@ class DirectmessagesTest < ActionDispatch::IntegrationTest
   # end
   #
   # test "a user can send a DM to another user" do
-  #   skip
   #   get message_new_path(@michael)
   #   assert_difference "Directmessages.count", 1 do
   #     post message_create_path(sender_id: @michael.id, receiver_id: @archer.id, content: "Super Test Message")
@@ -45,7 +41,6 @@ class DirectmessagesTest < ActionDispatch::IntegrationTest
   # end
   #
   # test "a user can view messages they have sent" do
-  #   skip
   #   get messages_sent_path(@michael)
   #   assert_select 'a', {count: 1, text: "M->A1"}
   #   assert_select 'a', {count: 1, text: "M->A2"}
@@ -53,7 +48,6 @@ class DirectmessagesTest < ActionDispatch::IntegrationTest
   # end
   #
   # test "a user can view messages they have received" do
-  #   skip
   #   get messages_received_path(@michael)
   #   assert_select 'a', {count: 1, text: "A->M1"}
   #   assert_select 'a', {count: 1, text: "A->M2"}
@@ -61,7 +55,6 @@ class DirectmessagesTest < ActionDispatch::IntegrationTest
   # end
   #
   # test "a user cannot view messages they did not send or receive to another user" do
-  #   skip
   # end
 
 


### PR DESCRIPTION
User sees the direct message link on another user's page, but not their own.

Add a lookup index on Directmessage sender and receiver ids. Setup foreign key connection between User table and sender/receiver ids.
